### PR TITLE
Honor productionOnly for browser routing

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -2,6 +2,7 @@ import defaultOptions from './default-options';
 
 export function onRouteUpdate({ location }, pluginOptions) {
     const { productionOnly } = Object.assign(
+        {},
         defaultOptions,
         pluginOptions
     );

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,15 @@
-export function onRouteUpdate({ location }) {
-    if (process.env.NODE_ENV !== 'production' || !Array.isArray(window._hsq)) {
+import defaultOptions from './default-options';
+
+export function onRouteUpdate({ location }, pluginOptions) {
+    const { productionOnly } = Object.assign(
+        defaultOptions,
+        pluginOptions
+    );
+    
+    if (
+        (productionOnly && process.env.NODE_ENV !== 'production') ||
+        !Array.isArray(window._hsq)
+    ) {
         return;
     }
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -4,6 +4,7 @@ import defaultOptions from './default-options';
 
 export function onRenderBody({ setPostBodyComponents }, pluginOptions) {
     const { productionOnly, respectDNT, trackingCode } = Object.assign(
+        {},
         defaultOptions,
         pluginOptions
     );


### PR DESCRIPTION
productionOnly option wasn't being respected client-side making it difficult to test