### PR TITLE
Add gatsby version 3 to peerDependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.4.2"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"
   }


### PR DESCRIPTION
This should remove the warning when running gatsby version 3:
`warn Plugin gatsby-plugin-hubspot is not compatible with your gatsby version 3.2.1 - It requires gatsby@^2.0.0`